### PR TITLE
Fix windows Handle drop

### DIFF
--- a/termal_core/src/raw/sys/windows.rs
+++ b/termal_core/src/raw/sys/windows.rs
@@ -164,7 +164,7 @@ impl Handle {
 
 impl Drop for Handle {
     fn drop(&mut self) {
-        if self.close && unsafe { CloseHandle(self.handle) != 0 } {
+        if self.close && unsafe { CloseHandle(self.handle) == 0 } {
             panic!("Failed to close handle: {}", io::Error::last_os_error());
         }
     }


### PR DESCRIPTION
Fix windows Handle drop function, which caused a lot of things not working on windows.